### PR TITLE
Suppress serialisable warnings

### DIFF
--- a/src/main/java/seedu/address/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/address/commons/core/GuiSettings.java
@@ -8,6 +8,7 @@ import java.util.Objects;
  * A Serializable class that contains the GUI settings.
  * Guarantees: immutable.
  */
+@SuppressWarnings("serial")
 public class GuiSettings implements Serializable {
 
     private static final double DEFAULT_HEIGHT = 600;

--- a/src/main/java/seedu/address/commons/exceptions/DataConversionException.java
+++ b/src/main/java/seedu/address/commons/exceptions/DataConversionException.java
@@ -3,6 +3,7 @@ package seedu.address.commons.exceptions;
 /**
  * Represents an error during conversion of data from one format to another
  */
+@SuppressWarnings("serial")
 public class DataConversionException extends Exception {
     public DataConversionException(Exception cause) {
         super(cause);

--- a/src/main/java/seedu/address/commons/exceptions/IllegalValueException.java
+++ b/src/main/java/seedu/address/commons/exceptions/IllegalValueException.java
@@ -3,6 +3,7 @@ package seedu.address.commons.exceptions;
 /**
  * Signals that some given data does not fulfill some constraints.
  */
+@SuppressWarnings("serial")
 public class IllegalValueException extends Exception {
     /**
      * @param message should contain relevant information on the failed constraint(s)

--- a/src/main/java/seedu/address/commons/util/JsonUtil.java
+++ b/src/main/java/seedu/address/commons/util/JsonUtil.java
@@ -113,6 +113,7 @@ public class JsonUtil {
     /**
      * Contains methods that retrieve logging level from serialized string.
      */
+    @SuppressWarnings("serial")
     private static class LevelDeserializer extends FromStringDeserializer<Level> {
 
         protected LevelDeserializer(Class<?> vc) {

--- a/src/main/java/seedu/address/logic/commands/exceptions/CommandException.java
+++ b/src/main/java/seedu/address/logic/commands/exceptions/CommandException.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands.exceptions;
 /**
  * Represents an error which occurs during execution of a {@link Command}.
  */
+@SuppressWarnings("serial")
 public class CommandException extends Exception {
     public CommandException(String message) {
         super(message);

--- a/src/main/java/seedu/address/logic/parser/exceptions/ParseException.java
+++ b/src/main/java/seedu/address/logic/parser/exceptions/ParseException.java
@@ -5,6 +5,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 /**
  * Represents a parse error encountered by a parser.
  */
+@SuppressWarnings("serial")
 public class ParseException extends IllegalValueException {
 
     public ParseException(String message) {

--- a/src/main/java/seedu/address/model/recipe/exceptions/DuplicateRecipeException.java
+++ b/src/main/java/seedu/address/model/recipe/exceptions/DuplicateRecipeException.java
@@ -4,6 +4,7 @@ package seedu.address.model.recipe.exceptions;
  * Signals that the operation will result in duplicate Recipes (Recipes are considered duplicates if they have the same
  * identity).
  */
+@SuppressWarnings("serial")
 public class DuplicateRecipeException extends RuntimeException {
     public DuplicateRecipeException() {
         super("Operation would result in duplicate recipes");

--- a/src/main/java/seedu/address/model/recipe/exceptions/RecipeNotFoundException.java
+++ b/src/main/java/seedu/address/model/recipe/exceptions/RecipeNotFoundException.java
@@ -3,4 +3,5 @@ package seedu.address.model.recipe.exceptions;
 /**
  * Signals that the operation is unable to find the specified recipe.
  */
+@SuppressWarnings("serial")
 public class RecipeNotFoundException extends RuntimeException {}


### PR DESCRIPTION
There is no real need to create serialisable classes; these are meant to be sent over a network. Our project is local, so we can suppress these warnings. 