### PR TITLE
Prevent additional arguments when using count

### DIFF
--- a/src/main/java/cookbuddy/logic/parser/RecipeBookParser.java
+++ b/src/main/java/cookbuddy/logic/parser/RecipeBookParser.java
@@ -92,7 +92,7 @@ public class RecipeBookParser {
             return new TimeCommandParser().parse(arguments);
 
         case CountCommand.COMMAND_WORD:
-            if(arguments != null) {
+            if (arguments != null) {
                 throw new ParseException("The count command does not take in any arguments!");
             }
             return new CountCommand();

--- a/src/main/java/cookbuddy/logic/parser/RecipeBookParser.java
+++ b/src/main/java/cookbuddy/logic/parser/RecipeBookParser.java
@@ -92,6 +92,9 @@ public class RecipeBookParser {
             return new TimeCommandParser().parse(arguments);
 
         case CountCommand.COMMAND_WORD:
+            if(arguments != null) {
+                throw new ParseException("The count command does not take in any arguments!");
+            }
             return new CountCommand();
 
         case ExitCommand.COMMAND_WORD:


### PR DESCRIPTION
Prevent additional arguments when using the `count` command