### PR TITLE
prevent exit command from accepting arguments

### DIFF
--- a/src/main/java/cookbuddy/logic/parser/RecipeBookParser.java
+++ b/src/main/java/cookbuddy/logic/parser/RecipeBookParser.java
@@ -98,6 +98,9 @@ public class RecipeBookParser {
             return new CountCommand();
 
         case ExitCommand.COMMAND_WORD:
+            if (!arguments.equals("")) {
+                throw new ParseException("The exit command does not take in any arguments!");
+            }
             return new ExitCommand();
 
         case HelpCommand.COMMAND_WORD:


### PR DESCRIPTION
fixing a very serious bug kindly pointed out by a bug hunter extraordinaire