### PR TITLE
Prevent reset command from taking in arguments

### DIFF
--- a/src/main/java/cookbuddy/logic/parser/RecipeBookParser.java
+++ b/src/main/java/cookbuddy/logic/parser/RecipeBookParser.java
@@ -74,6 +74,9 @@ public class RecipeBookParser {
             return new UnFavCommandParser().parse(arguments);
 
         case ResetCommand.COMMAND_WORD:
+            if (!arguments.equals("")) {
+                throw new ParseException(("The reset command does not take in any arguments!"));
+            }
             return new ResetCommand();
 
         case ViewCommand.COMMAND_WORD:


### PR DESCRIPTION
Prevent reset command from taking in any arguments

- [x] Negative test case

- [x] Positive test case